### PR TITLE
Revert "Backport from mainline"

### DIFF
--- a/gcc/testsuite/gcc.target/i386/bmi-6.c
+++ b/gcc/testsuite/gcc.target/i386/bmi-6.c
@@ -1,5 +1,4 @@
 /* { dg-do link } */
-/* { dg-xfail-if "PR 78057" { "*-*-*" } { "*" } { "" } } */
 /* { dg-options "-O2 -mbmi" } */
 
 #include <x86intrin.h>


### PR DESCRIPTION
   testsuite/ChangeLog:

            * gcc.target/i386/bmi-6.c: XFAIL.

This reverts commit 3f9c4af071a4cefece8761fa1e37878105ff4d16.