### PR TITLE
gcc: don't set the default RPATH for -static-pie binaries.

### DIFF
--- a/gcc/gcc.cc
+++ b/gcc/gcc.cc
@@ -2082,9 +2082,10 @@ init_spec (void)
   /* Prepend --rpath=LINKER_RPATH to whatever link_spec we had
      before.  */
   {
-    static const char rpath[] = "--rpath=";
+    static const char rpath[] = "%{!static-pie:--rpath=";
     obstack_grow (&obstack, rpath, sizeof (rpath) - 1);
     obstack_grow (&obstack, LINKER_RPATH, sizeof (LINKER_RPATH) - 1);
+    obstack_1grow (&obstack, '}');
     obstack_1grow (&obstack, ' ');
   }
 # endif


### PR DESCRIPTION
If the compiler was configured --with-linker-rpath= then don't add the default RPATH to -static-pie binaries.

        * gcc/gcc.c (init_spec): Set the default LINKER_RPATH only if
	  not building static binaries with PIE (-static-pie).